### PR TITLE
dependency: include localforage dependency

### DIFF
--- a/Front-end-test-converter/angular.json
+++ b/Front-end-test-converter/angular.json
@@ -18,13 +18,12 @@
         "build": {
           "builder": "@angular-devkit/build-angular:application",
           "options": {
+            "allowedCommonJsDependencies": ["localforage"],
             "outputPath": {
               "base": "www"
             },
             "index": "src/index.html",
-            "polyfills": [
-              "src/polyfills.ts"
-            ],
+            "polyfills": ["src/polyfills.ts"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -128,9 +127,7 @@
     }
   },
   "cli": {
-    "schematicCollections": [
-      "@ionic/angular-toolkit"
-    ],
+    "schematicCollections": ["@ionic/angular-toolkit"],
     "analytics": false
   },
   "schematics": {

--- a/Front-end-test-converter/package-lock.json
+++ b/Front-end-test-converter/package-lock.json
@@ -27,6 +27,7 @@
         "front-end-test-converter": "file:",
         "Front-end-test-converter": "file:",
         "ionicons": "^7.0.0",
+        "localforage": "^1.10.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"

--- a/Front-end-test-converter/package.json
+++ b/Front-end-test-converter/package.json
@@ -32,6 +32,7 @@
     "front-end-test-converter": "file:",
     "Front-end-test-converter": "file:",
     "ionicons": "^7.0.0",
+    "localforage": "^1.10.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"


### PR DESCRIPTION
Include dependency used by 'node_modules/@ionic/storage/dist/esm/index.js' and set option allowed common js dependencies on angular.json to fix this warning